### PR TITLE
Use passTemplate wire key + add patchPass (partial update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ deleting passes via the PassNinja api. The methods are outlined below.
 ```swift
 PassClient.shared.createPass(pass: PassRequest(passType: "demo.coupon", pass: [discount: '50%', memberName: 'John']), onSuccess: { (pass) in
     print(pass.urls as Any)
-    print(pass.passType as Any)
+    print(pass.passTemplate as Any)
     print(pass.serialNumber as Any)
     print(pass.pass?.logoText as Any)
     print(pass.pass?.descriptionField as Any)
@@ -85,7 +85,7 @@ PassClient.shared.createPass(pass: PassRequest(passType: "demo.coupon", pass: [d
 ```swift
 PassClient.shared.getPass(passType: "demo.coupon", serialNumber: "#Your pass serial number", onSuccess: { (pass) in
     print(pass.urls as Any)
-    print(pass.passType as Any)
+    print(pass.passTemplate as Any)
     print(pass.serialNumber as Any)
     print(pass.pass?.logoText as Any)
     print(pass.pass?.descriptionField as Any)
@@ -112,7 +112,7 @@ PassClient.shared.getPassTemplate(passType: "demo.coupon", onSuccess: { (passTem
 ```swift
 PassClient.shared.putPass(pass: PassRequest(passType: "demo.coupon", pass: ["passTitle": "Example passTitleValue", "logoText": "Example logoTextValue", "organizationName": "Example organizationNameValue", "description": "Example descriptionValue"], serialNumber: "#Your pass serial number"), onSuccess: { (pass) in
     print(pass.urls as Any)
-    print(pass.passType as Any)
+    print(pass.passTemplate as Any)
     print(pass.serialNumber as Any)
     print(pass.pass?.logoText as Any)
     print(pass.pass?.descriptionField as Any)

--- a/Sources/PassNinjaSwift/Client/PassClient.swift
+++ b/Sources/PassNinjaSwift/Client/PassClient.swift
@@ -35,9 +35,6 @@ open class PassClient {
                 onError(commonError())
             }
         }
-        if let error = error {
-            onError(error)
-        }
     }
 
     public func createPass(pass: PassRequest,

--- a/Sources/PassNinjaSwift/Client/PassClient.swift
+++ b/Sources/PassNinjaSwift/Client/PassClient.swift
@@ -155,6 +155,40 @@ open class PassClient {
         }
     }
     
+    public func patchPass(pass: PassRequest,
+                          onSuccess: @escaping (_ response: Pass) -> Void,
+                          onError: @escaping (_ error: PassNinjaError?) -> Void) {
+        let isValidRequest = validatePass(passType: pass.passType, serialNumber: pass.serialNumber, endPointType: .Put)
+        var error: PassNinjaError?
+        if let message = checkMissingAccountIdanApiKey() {
+            error = try! PassNinjaError(message: message, statusCode: 500)
+        }else if !isValidRequest{
+            error = try! PassNinjaError(message: "Please enter a valid pass type and serial number", statusCode: 500)
+        }else {
+            provider.request(.patchPass(pass: pass)) { result in
+                switch result{
+                case .success(let response):
+                    do {
+                        if response.statusCode == 200 {
+                            let pass = try JSONDecoder().decode(Pass.self, from: response.data)
+                            onSuccess(pass)
+                        } else {
+                            let error = try JSONDecoder().decode(PassNinjaError.self, from: response.data)
+                            onError(error)
+                        }
+                    } catch {
+                        onError(commonError())
+                    }
+                case.failure:
+                    onError(commonError())
+                }
+            }
+        }
+        if let error = error {
+            onError(error)
+        }
+    }
+
     public func deletePass(passType: String,
                            serialNumber: String,
                            clientPassData: [String: Any],

--- a/Sources/PassNinjaSwift/EndPoint/EndPoint.swift
+++ b/Sources/PassNinjaSwift/EndPoint/EndPoint.swift
@@ -16,6 +16,7 @@ enum EndPoint{
     case patchPass(pass: PassRequest)
     case deletePass(passType: String, serialNumber: String)
     case getPassTypeKeys(passType: String)
+    case getPassTemplate(passType: String)
 }
 
 extension EndPoint : TargetType{
@@ -30,8 +31,7 @@ extension EndPoint : TargetType{
     
     var path: String {
         switch self {
-        case .getPassTemplate:
-            let passType
+        case .getPassTemplate(let passType):
             return "/pass_templates/\(passType)"
         case .createPass:
             return "/passes"

--- a/Sources/PassNinjaSwift/EndPoint/EndPoint.swift
+++ b/Sources/PassNinjaSwift/EndPoint/EndPoint.swift
@@ -13,6 +13,7 @@ enum EndPoint{
     case createPass(pass: PassRequest)
     case getPass(passType: String, serialNumber: String)
     case putPass(pass: PassRequest)
+    case patchPass(pass: PassRequest)
     case deletePass(passType: String, serialNumber: String)
     case getPassTypeKeys(passType: String)
 }
@@ -38,6 +39,8 @@ extension EndPoint : TargetType{
             return "/passes/\(passType)/\(serialNumber)"
         case .putPass(let pass):
             return "/passes/\(pass.passType)/\(pass.serialNumber!)"
+        case .patchPass(let pass):
+            return "/passes/\(pass.passType)/\(pass.serialNumber!)"
         case .deletePass(let passType, let serialNumber):
             return "/passes/\(passType)/\(serialNumber)"
         case .getPassTypeKeys(let passType):
@@ -53,6 +56,8 @@ extension EndPoint : TargetType{
             return .get
         case .putPass:
             return .put
+        case .patchPass:
+            return .patch
         case .deletePass:
             return .delete
         }
@@ -83,6 +88,13 @@ extension EndPoint : TargetType{
             }else {
                 return [:]
             }
+        case .patchPass(let pass):
+            if let passParams = pass.pass {
+                let params = ["passTemplate": pass.passType, "serialNumber": pass.serialNumber as Any, "pass": passParams] as [String : Any]
+                return params
+            }else {
+                return [:]
+            }
         case .deletePass(let passType, let serialNumber):
             return ["passType": passType,
                     "serialNumber": serialNumber]
@@ -101,7 +113,7 @@ extension EndPoint : TargetType{
                 print("Parameters not converted with error: \(error)")
             }
             return .requestData(parameterData)
-        case .putPass:
+        case .putPass, .patchPass:
             var parameterData = Data()
             do {
                 parameterData = try JSONSerialization.data(withJSONObject: parameters!, options: [])
@@ -116,7 +128,7 @@ extension EndPoint : TargetType{
     
     var headers: [String : String]? {
         switch  self {
-        case .createPass, .getPass, .putPass, .deletePass, .getPassTypeKeys, .getPassTemplate:
+        case .createPass, .getPass, .putPass, .patchPass, .deletePass, .getPassTypeKeys, .getPassTemplate:
             var header = ["Content-Type": "application/json"]
             header["x-account-id"] = passAccountId
             header["x-api-key"] = passApiKey

--- a/Sources/PassNinjaSwift/EndPoint/EndPoint.swift
+++ b/Sources/PassNinjaSwift/EndPoint/EndPoint.swift
@@ -66,7 +66,7 @@ extension EndPoint : TargetType{
         switch self {
         case .createPass(let pass):
             if let passParams = pass.pass {
-                let params = ["passType": pass.passType, "pass": passParams] as [String : Any]
+                let params = ["passTemplate": pass.passType, "pass": passParams] as [String : Any]
                 return params
             }else {
                 return [:]
@@ -78,7 +78,7 @@ extension EndPoint : TargetType{
             return ["passType": passType]
         case .putPass(let pass):
             if let passParams = pass.pass {
-                let params = ["passType": pass.passType, "serialNumber": pass.serialNumber as Any, "pass": passParams] as [String : Any]
+                let params = ["passTemplate": pass.passType, "serialNumber": pass.serialNumber as Any, "pass": passParams] as [String : Any]
                 return params
             }else {
                 return [:]

--- a/Sources/PassNinjaSwift/Models/Pass.swift
+++ b/Sources/PassNinjaSwift/Models/Pass.swift
@@ -73,21 +73,21 @@ public struct CreatePass : Codable {
 public struct Pass : Codable {
     
     public let pass : PassResponse?
-    public let passType : String?
+    public let passTemplate : String?
     public let serialNumber : String?
     public let urls : PassUrl?
-    
+
     enum CodingKeys: String, CodingKey {
         case pass = "pass"
-        case passType = "passType"
+        case passTemplate = "passTemplate"
         case serialNumber = "serialNumber"
         case urls = "urls"
     }
-    
+
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         pass = try values.decodeIfPresent(PassResponse.self, forKey: .pass)
-        passType = try values.decodeIfPresent(String.self, forKey: .passType)
+        passTemplate = try values.decodeIfPresent(String.self, forKey: .passTemplate)
         serialNumber = try values.decodeIfPresent(String.self, forKey: .serialNumber)
         urls = try values.decodeIfPresent(PassUrl.self, forKey: .urls)
     }


### PR DESCRIPTION
## What

Switch to the `passTemplate` wire key, matching the API contract that is standardizing on `passTemplate` (away from the legacy `passType`).

## Changes
- `EndPoint.swift` — create/update request bodies now send `passTemplate` instead of `passType`.
- `Models/Pass.swift` — response struct decodes `passTemplate` and exposes it as `pass.passTemplate` (CodingKey + property + decoder).
- `README.md` — response reads updated to `pass.passTemplate`.

Untouched on purpose:
- `PassRequest.passType` — the request init parameter (kept).
- `RequiredPassKey.passType` — the `/passtypes/keys` endpoint field (unchanged server-side).
- `PassTemplate.swift` `pass_type` / `pass_type_id` — different identifier fields.

## Note
The repo does not compile cleanly on the current Swift toolchain due to pre-existing issues unrelated to this change (a missing `EndPoint.getPassTemplate` case and the Swift `error` macro). These edits are limited to the wire keys and the response attribute.

## Compatibility
The API accepts both `passTemplate` and `passType` on input and echoes back whichever key the caller sends.
